### PR TITLE
Remove course code from discovery course card

### DIFF
--- a/lms/templates/discovery/course_card.underscore
+++ b/lms/templates/discovery/course_card.underscore
@@ -2,7 +2,7 @@
     <a href="/courses/<%- course %>/about">
         <header class="course-image">
             <div class="cover-image">
-                <img src="<%- image_url %>" alt="<%- content.display_name %> <%- content.number %>" />
+                <img src="<%- image_url %>" alt="<%- content.display_name %>" />
                 <div class="learn-more" aria-hidden="true"><%- gettext("LEARN MORE") %></div>
             </div>
             <div class="partner-logo-wrapper">
@@ -12,7 +12,6 @@
         <section class="course-info" aria-hidden="true">
             <h2 class="course-name">
                 <span class="course-organization"><%- org %></span>
-                <span class="course-code"><%- content.number %></span>
                 <span class="course-title"><%- content.display_name %></span>
             </h2>
             <div class="course-date" aria-hidden="true">
@@ -25,7 +24,6 @@
         <div class="sr">
             <ul>
                 <li><%- org %></li>
-                <li><%- content.number %></li>
                 <li><%- gettext("Starts") %><time itemprop="startDate" datetime="<%- start %>"><%- start %></time></li>
             </ul>
         </div>


### PR DESCRIPTION
Removed all references to the course code (content.number) from the discovery course card:

- Deleted course code span from the title section
- Removed course code <li> from screen reader section
- Removed course code from alt attributes of course images

UI and accessibility remain intact; course code can be added later if needed