### PR TITLE
Fix footer overlap and spacing issue on course about page

### DIFF
--- a/lms/static/custom_css/course_about.css
+++ b/lms/static/custom_css/course_about.css
@@ -1085,3 +1085,16 @@ body.is-dark-theme .instructor-title-org {
     flex: 0 0 100% !important;
   }
 }
+/* this is to safe the space if the content is empty.  -solution2  */
+html, body {
+  height: 100%;
+}
+
+.course-info body {
+  display: flex;
+  flex-direction: column;
+}
+
+.course-info .content-wrapper {
+  flex: 1;
+}

--- a/lms/static/js/scroll-footer.js
+++ b/lms/static/js/scroll-footer.js
@@ -121,7 +121,7 @@
     const isScrollable = isPageScrollable();
     if (!isScrollable) {
       // If not scrollable, always show footer and skip toggling logic
-      setContentPadding(false);
+      setContentPadding(true); /* solution1-if we keep true even if its not scrollable then content padding still works and overlapping doesnt happen*/
       showFooter(true);
       return;
     }


### PR DESCRIPTION
**Problem**
- Footer overlapped content when course about page had little or no content.

**Root Cause**
- Scrollable footer logic (scroll-footer.js) was not handling non-scrollable pages correctly, causing layout inconsistencies.

**Solution**
- Updated scroll-footer padding logic
- Applied flex layout to maintain full page height
- Ensured footer stays at bottom without unnecessary spacing

**Testing**
- Tested with empty course content
- Tested with populated course content
- Verified responsiveness
