### PR TITLE
chore: add ulmo.1 migration changes

### DIFF
--- a/cms/templates/widgets/header.html
+++ b/cms/templates/widgets/header.html
@@ -8,7 +8,7 @@
   from urllib.parse import quote_plus
   from common.djangoapps.student.auth import has_studio_advanced_settings_access
   from cms.djangoapps.contentstore import toggles
-  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url
+  from cms.djangoapps.contentstore.utils import get_pages_and_resources_url, get_course_outline_url, get_course_libraries_url, get_updates_url, get_files_uploads_url, get_video_uploads_url, get_schedule_details_url, get_grading_url, get_advanced_settings_url, get_import_url, get_export_url, get_studio_home_url, get_course_team_url, get_optimizer_url
   from openedx.core.djangoapps.discussions.config.waffle import ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND
   from openedx.core.djangoapps.lang_pref.api import header_language_selector_is_enabled, released_languages
 %>
@@ -16,22 +16,12 @@
   <header class="primary" role="banner">
     <div class="wrapper wrapper-l">
       <h1 class="branding">
-        % if not toggles.use_new_home_page():
-        <a class="brand-link" href="/">
-          <img class="brand-image" src="${static.url('images/studio-logo.png')}" alt="${settings.STUDIO_NAME}" />
-            % if settings.LOGO_IMAGE_EXTRA_TEXT == 'edge':
-            <span class="font-italic"> <span class="tilted">|</span> EDGE</span>
-            % endif
-        </a>
-        % endif
-        % if toggles.use_new_home_page():
         <a class="brand-link" href="${get_studio_home_url()}">
           <img class="brand-image" src="${static.url('images/studio-logo.png')}" alt="${settings.STUDIO_NAME}" />
             % if settings.LOGO_IMAGE_EXTRA_TEXT == 'edge':
             <span class="font-italic"> <span class="tilted">|</span> EDGE</span>
             % endif
         </a>
-        % endif
 
       </h1>
 
@@ -56,9 +46,7 @@
                 certificates_url = reverse('certificates_list_handler', kwargs={'course_key_string': str(course_key)})
             checklists_url = reverse('checklists_handler', kwargs={'course_key_string': str(course_key)})
             pages_and_resources_mfe_enabled = ENABLE_PAGES_AND_RESOURCES_MICROFRONTEND.is_enabled(context_course.id)
-            course_outline_mfe_enabled = toggles.use_new_course_outline_page(context_course.id)
             updates_mfe_enabled = toggles.use_new_updates_page(context_course.id)
-            files_uploads_mfe_enabled = toggles.use_new_files_uploads_page(context_course.id)
             video_upload_mfe_enabled = toggles.use_new_video_uploads_page(context_course.id)
             schedule_details_mfe_enabled = toggles.use_new_schedule_details_page(context_course.id)
             grading_mfe_enabled = toggles.use_new_grading_page(context_course.id)
@@ -66,22 +54,16 @@
             advanced_settings_mfe_enabled = toggles.use_new_advanced_settings_page(context_course.id)
             import_mfe_enabled = toggles.use_new_import_page(context_course.id)
             export_mfe_enabled = toggles.use_new_export_page(context_course.id)
+            optimizer_enabled = toggles.enable_course_optimizer(context_course.id)
+            libraries_v2_enabled = toggles.libraries_v2_enabled()
 
       %>
       <h2 class="info-course">
         <span class="sr">${_("Current Course:")}</span>
-        % if not course_outline_mfe_enabled:
-        <a class="course-link" href="${index_url}">
-          <span class="course-org">${context_course.display_org_with_default}</span><span class="course-number">${context_course.display_number_with_default}</span>
-          <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
-        </a>
-        % endif
-        % if course_outline_mfe_enabled:
         <a class="course-link" href="${get_course_outline_url(course_key)}">
           <span class="course-org">${context_course.display_org_with_default}</span><span class="course-number">${context_course.display_number_with_default}</span>
           <span class="course-title" title="${context_course.display_name_with_default}">${context_course.display_name_with_default}</span>
         </a>
-        % endif
       </h2>
 
       <nav class="nav-course nav-dd ui-left" aria-label="${_('Course')}">
@@ -93,14 +75,12 @@
             <div class="wrapper wrapper-nav-sub">
               <div class="nav-sub">
                 <ul>
-                  % if not course_outline_mfe_enabled:
-                  <li class="nav-item nav-course-courseware-outline">
-                    <a href="${index_url}">${_("Outline")}</a>
-                  </li>
-                  % endif
-                  % if course_outline_mfe_enabled:
                   <li class="nav-item nav-course-courseware-outline">
                     <a href="${get_course_outline_url(course_key)}">${_("Outline")}</a>
+                  </li>
+                  % if libraries_v2_enabled:
+                  <li class="nav-item nav-course-courseware-outline">
+                    <a href="${get_course_libraries_url(course_key)}">${_("Libraries")}</a>
                   </li>
                   % endif
                   % if not updates_mfe_enabled:
@@ -123,16 +103,9 @@
                     <a href="${get_pages_and_resources_url(course_key)}">${_("Pages & Resources")}</a>
                   </li>
                   % endif
-                  %if not files_uploads_mfe_enabled:
-                  <li class="nav-item nav-course-courseware-uploads">
-                    <a href="${assets_url}">${_("Files")}</a>
-                  </li>
-                  %endif
-                  %if files_uploads_mfe_enabled:
                   <li class="nav-item nav-course-courseware-uploads">
                     <a href="${get_files_uploads_url(course_key)}">${_("Files")}</a>
                   </li>
-                  %endif
                   % if not pages_and_resources_mfe_enabled:
                   <li class="nav-item nav-course-courseware-textbooks">
                     <a href="${textbooks_url}">${_("Textbooks")}</a>
@@ -202,14 +175,11 @@
                     <a href="${advanced_settings_url}">${_("Advanced Settings")}</a>
                   </li>
                   % endif
-
                   % if has_studio_advanced_settings_access(request.user) and advanced_settings_mfe_enabled:
                   <li class="nav-item nav-course-settings-advanced">
                     <a href="${get_advanced_settings_url(course_key)}">${_("Advanced Settings")}</a>
                   </li>
                   % endif
-
-          
                   <li class="nav-item nav-course-settings-course-modes">
                     <a href="${reverse('course_modes_handler', kwargs={'course_key_string': str(course_key)})}">${_("Course Modes")}</a>
                   </li>
@@ -249,7 +219,7 @@
                   </li>
                   % endif
                   % if export_mfe_enabled:
-                  <li class="nav-item nav-course-tools-import">
+                  <li class="nav-item nav-course-tools-export">
                     <a href="${get_export_url(course_key)}">${_("Export")}</a>
                   </li>
                   % endif
@@ -261,6 +231,11 @@
                   <li class="nav-item nav-course-tools-checklists">
                     <a href="${checklists_url}">${_("Checklists")}</a>
                   </li>
+                  % if optimizer_enabled:
+                  <li class="nav-item">
+                    <a href="${get_optimizer_url(course_key)}">${_("Course Optimizer")}</a>
+                  </li>
+                  % endif
                 </ul>
               </div>
             </div>

--- a/lms/templates/courseware/course_about.html
+++ b/lms/templates/courseware/course_about.html
@@ -19,7 +19,17 @@ from openedx.core.djangoapps.models.course_details import CourseDetails
 
 <%inherit file="../main.html" />
 <%block name="headextra">
-    ## OG (Open Graph) title and description added below to give social media info to display
+    <%
+        site_domain = static.get_value('site_domain', settings.SITE_NAME)
+        site_protocol = 'https' if settings.HTTPS == 'on' else 'http'
+
+        og_img_url = "{protocol}://{domain}{path}".format(
+            protocol=site_protocol,
+            domain=site_domain,
+            path=course_image_urls['large']
+        )
+    %>
+    ## OG (Open Graph) title, image and description added below to give social media info to display
     ## (https://developers.facebook.com/docs/opengraph/howtos/maximizing-distribution-media-content#tags)
     <meta property="og:title" content="${course.display_name_with_default}" />
     <meta property="og:description" content="${get_course_about_section(request, course, 'short_description') or ''}" />

--- a/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
+++ b/lms/templates/instructor/instructor_dashboard_2/instructor_dashboard_2.html
@@ -62,7 +62,6 @@ from openedx.core.djangolib.js_utils import (
   <%static:webpack entry='HtmlBlockEditor'/>
   <link rel="stylesheet" href="${static.url('css/HtmlBlockEditor.css')}">
   <%static:js group='instructor_dash'/>
-  <%static:js group='application'/>
 
   ## Backbone classes declared explicitly until RequireJS is supported
   <script type="text/javascript" src="${static.url('js/models/notification.js')}"></script>


### PR DESCRIPTION
While updating from `sumac.2` to `ulmo.1` version, some of the files were not updated as per template changes in `edx-platform`.

Which may cause some unwanted errors/bugs in the django template related pages. One such known example is that `legacy` library were giving errors when you try to open them.

This PR syncs new changes in all the template files in `Sherab-theme` with `release/ulmo.1` tag of `edx-platform`. 

Related ticket:
https://github.com/OpenPecha/Sherab-Project/issues/333