### PR TITLE
fix: certificate PDF layout, partner logo capture, and download size

### DIFF
--- a/lms/static/custom_css/certificate.css
+++ b/lms/static/custom_css/certificate.css
@@ -260,6 +260,12 @@
 	margin-bottom: 0 !important;
 	width: 1200px !important;
 	max-width: none !important;
+	align-items: stretch !important;
+	box-shadow: none !important;
+}
+
+.cert-download-capture-mode .cert-left {
+	align-self: stretch !important;
 }
 
 .cert-download-capture-mode .wrapper-view,

--- a/lms/templates/certificates/_accomplishment-rendering.html
+++ b/lms/templates/certificates/_accomplishment-rendering.html
@@ -1,5 +1,8 @@
 <%page expression_filter="h"/>
 <%!
+	import base64
+	import mimetypes
+
 	from django.utils.translation import gettext as _
 	from django.conf import settings
 	from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
@@ -15,6 +18,7 @@
 
 	# PARTNER (LOGO + NAME)
 	partner_logo = None
+	partner_logo_src = None
 	partner_name = "Partner"
 	try:
 		# Fetch the organization course record associated with the given course_id
@@ -32,6 +36,18 @@
 			partner = partner_org_mapping.partner
 			partner_logo = partner.logo if partner and partner.logo else None
 			partner_name = partner.name if partner and partner.name else "Partner"
+
+		# Inline the partner logo so html2canvas can paint it without CORS issues.
+		if partner_logo:
+			try:
+				mime_type = mimetypes.guess_type(partner_logo.name)[0] or "image/png"
+				with partner_logo.open("rb") as logo_file:
+					partner_logo_src = "data:{};base64,{}".format(
+						mime_type,
+						base64.b64encode(logo_file.read()).decode("ascii"),
+					)
+			except Exception:
+				partner_logo_src = partner_logo.url if getattr(partner_logo, "url", None) else partner_logo
 	except Exception:
 		pass
 
@@ -63,8 +79,10 @@
     <div class="cert-right">
 		<div class="cert-header">
 			<div class="cert-logo-wrapper">
-				% if partner_logo:
-					<img src="${partner_logo.url if getattr(partner_logo, 'url', None) else partner_logo}" alt="${platform_name}"
+				% if partner_logo_src:
+					<img src="${partner_logo_src}" alt="${partner_name}" class="cert-logo">
+				% elif partner_logo:
+					<img src="${partner_logo.url if getattr(partner_logo, 'url', None) else partner_logo}" alt="${partner_name}"
 						class="cert-logo">
 				% else:
 					<img src="${static.url('images/logo.png')}" alt="${platform_name}" class="cert-logo">

--- a/lms/templates/certificates/_assets-secondary.html
+++ b/lms/templates/certificates/_assets-secondary.html
@@ -42,6 +42,9 @@
                     return loadScript("https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js", "jsPDF");
                 })
                 .then(function() {
+                    return waitForCertificateImages(certificateElement);
+                })
+                .then(function() {
                     if (!window.html2canvas) {
                         throw createDownloadError("capture-missing", "Screenshot library unavailable");
                     }
@@ -49,7 +52,10 @@
                     return window.html2canvas(certificateElement, {
                         scale: 2,
                         useCORS: true,
+                        allowTaint: false,
                         backgroundColor: "#ffffff",
+                        width: Math.ceil(certificateElement.offsetWidth),
+                        height: Math.ceil(certificateElement.offsetHeight),
                         windowWidth: Math.ceil(certificateElement.scrollWidth),
                         windowHeight: Math.ceil(certificateElement.scrollHeight)
                     }).catch(function() {
@@ -63,30 +69,26 @@
                     }
 
                     try {
+                        // Size the PDF page to the captured certificate (no A4 letterboxing).
+                        // Divide by capture scale so page mm match CSS layout size.
+                        var captureScale = 2;
+                        var PX_TO_MM = 25.4 / 96;
+                        var pageWidth = (canvas.width / captureScale) * PX_TO_MM;
+                        var pageHeight = (canvas.height / captureScale) * PX_TO_MM;
                         var pdf = new jsPdfConstructor({
-                            orientation: "landscape",
+                            orientation: pageWidth >= pageHeight ? "landscape" : "portrait",
                             unit: "mm",
-                            format: "a4"
+                            format: [pageWidth, pageHeight]
                         });
-                        var pageWidth = pdf.internal.pageSize.getWidth();
-                        var pageHeight = pdf.internal.pageSize.getHeight();
-                        var imageWidth = canvas.width;
-                        var imageHeight = canvas.height;
-                        var imageRatio = imageWidth / imageHeight;
-                        var pageRatio = pageWidth / pageHeight;
-                        var renderWidth = pageWidth;
-                        var renderHeight = pageHeight;
 
-                        if (imageRatio > pageRatio) {
-                            renderHeight = pageWidth / imageRatio;
-                        } else {
-                            renderWidth = pageHeight * imageRatio;
-                        }
-
-                        var x = (pageWidth - renderWidth) / 2;
-                        var y = (pageHeight - renderHeight) / 2;
-
-                        pdf.addImage(canvas.toDataURL("image/png"), "PNG", x, y, renderWidth, renderHeight);
+                        pdf.addImage(
+                            canvas.toDataURL("image/jpeg", 1),
+                            "JPEG",
+                            0,
+                            0,
+                            pageWidth,
+                            pageHeight
+                        );
                         pdf.save(getCertificateFileName());
                     } catch (pdfError) {
                         throw createDownloadError("pdf-failed", "Failed to render certificate PDF");
@@ -102,6 +104,38 @@
                     document.body.classList.remove(captureModeClass);
                     restoreDownloadButton(downloadButton, originalButtonLabel);
                 });
+        }
+
+        function waitForCertificateImages(element) {
+            var images = element.querySelectorAll("img");
+
+            if (!images.length) {
+                return Promise.resolve();
+            }
+
+            return Promise.all(Array.prototype.map.call(images, function(img) {
+                if (img.complete && img.naturalWidth > 0) {
+                    return Promise.resolve();
+                }
+
+                return new Promise(function(resolve) {
+                    var settled = false;
+
+                    function finish() {
+                        if (settled) {
+                            return;
+                        }
+                        settled = true;
+                        resolve();
+                    }
+
+                    img.addEventListener("load", finish, { once: true });
+                    img.addEventListener("error", finish, { once: true });
+
+                    // Avoid hanging forever if the browser never fires load/error.
+                    setTimeout(finish, 5000);
+                });
+            }));
         }
 
         function getCertificateElement() {


### PR DESCRIPTION
## Summary
- Fix downloaded certificate PDFs showing white gaps top/bottom by sizing the jsPDF page to the screenshot instead of forcing A4 letterboxing.
- Fix missing course provider (partner) logo in the PDF by inlining the logo as base64 so html2canvas can paint it without CORS issues; wait for images before capture and tighten capture-mode CSS so the orange panel stays flush.
- Reduce download size from ~15MB to ~1.2MB by embedding JPEG (quality 1) at scale 2 instead of lossless PNG.

#Note: checked the prod certificate and the result is same.